### PR TITLE
fix: update lockfile via temporary workflow and enable dependency trackingfix: update lockfile via temporary workflow and remove workflowCreate temp-lockfile-update.yml

### DIFF
--- a/.github/workflows/temp-lockfile-update.yml
+++ b/.github/workflows/temp-lockfile-update.yml
@@ -1,0 +1,32 @@
+name: Temporary Lockfile Update
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          
+      - name: Clean install dependencies
+        run: |
+          rm -rf node_modules package-lock.json
+          npm install
+          
+      - name: Commit lockfile changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package-lock.json
+          git diff --staged --quiet || git commit -m "chore: update package-lock.json with fresh install"
+          git push


### PR DESCRIPTION
## Overview
This PR creates a temporary workflow to update package-lock.json and trigger GitHub's dependency graph update.

## What it does:
1. Adds a temporary workflow that runs `npm install` and commits the updated lockfile
2. The workflow will be removed after successfully updating the lockfile
3. This helps trigger GitHub's dependency graph update via Dependabot

## Actions needed after PR creation:
- [ ] Run the temporary workflow manually
- [ ] Wait for lockfile to be updated
- [ ] Remove the temporary workflow file
- [ ] Enable Dependabot if not already enabled

## Expected outcome:
- Updated package-lock.json with latest dependency resolution
- Triggered dependency graph update for better security scanning
- Clean PR with temporary workflow removed